### PR TITLE
Allowing JMX exporter to work with scalable kafka cluster using Rancher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Created by .ignore support plugin (hsz.mobi)
+### SBT template
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+target/
+lib_managed/
+src_managed/
+project/boot/
+.history
+.cache
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ kafka:
     - zookeeper
   ports:
     - "9092:9092"
+    - "9999:9999"
   environment:
     - KAFKA_ADVERTISED_HOST_NAME=192.168.99.100
     - KAFKA_ADVERTISED_PORT=9092
@@ -19,14 +20,13 @@ kafka:
     - JMX_PORT=9999
 
 kafka-jmx-exporter:
-  build: ./prometheus-jmx-exporter 
-  ports: 
-    - "8080:8080"  
+  build: ./prometheus-jmx-exporter
+  ports:
+    - "8080:8080"
   links:
     - kafka
   environment:
     - JMX_PORT=9999
-    - JMX_HOST=kafka
     - HTTP_PORT=8080
     - JMX_EXPORTER_CONFIG_FILE=kafka.yml
 

--- a/prometheus-jmx-exporter/confd/templates/start-jmx-scraper.sh.tmpl
+++ b/prometheus-jmx-exporter/confd/templates/start-jmx-scraper.sh.tmpl
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname={{ getv "/jmx/host" }} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port={{ getv "/jmx/port" }} -jar /opt/jmx_prometheus_httpserver/jmx_prometheus_httpserver.jar {{ getv "/http/port" }} /opt/jmx_prometheus_httpserver/{{ getv "/jmx/exporter/config/file" }}
+java -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$JMX_HOST -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port={{ getv "/jmx/port" }} -jar /opt/jmx_prometheus_httpserver/jmx_prometheus_httpserver.jar {{ getv "/http/port" }} /opt/jmx_prometheus_httpserver/{{ getv "/jmx/exporter/config/file" }}

--- a/prometheus-jmx-exporter/entrypoint.sh
+++ b/prometheus-jmx-exporter/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+if [[ -z "$JMX_HOST" ]]; then
+    export JMX_HOST=$(curl "http://rancher-metadata.rancher.internal/2015-07-25/self/host/agent_ip")
+fi
 /usr/local/bin/confd -onetime -backend env
 /opt/start-jmx-scraper.sh


### PR DESCRIPTION
For using with Rancher http://rancher.com/ : 
JMX Exporter needs to have access to a specific Kafka cluster container when scaled, this can solved by using Rancher metadata service to get the host container IP address and by exposing JMX port for each Kafka container.